### PR TITLE
Change lowercase "x" close button to uppercase.

### DIFF
--- a/mexui/Core/Component/Window.js
+++ b/mexui/Core/Component/Window.js
@@ -139,7 +139,7 @@ mexui.Component.Window.prototype.render = function()
 			// window title bar icons
 			var iconPos = this.getCloseIconPosition();
 			mexui.native.drawRectangle(iconPos, this.titleBarIconSize, this.getStyles('icon'));
-			mexui.native.drawText(iconPos, this.titleBarIconSize, 'x', this.getStyles('icon'));
+			mexui.native.drawText(iconPos, this.titleBarIconSize, 'X', this.getStyles('icon'));
 		}
 	}
 	


### PR DESCRIPTION
The lowercase "x" sits awkardly low and doesn't fit right